### PR TITLE
fix: prevent quick find from opening in firefox

### DIFF
--- a/public/sketch.js
+++ b/public/sketch.js
@@ -28,7 +28,8 @@ window.draw = function () {
     masterBranch.draw();
 }
 
-window.keyPressed = function(){
+window.keyPressed = function(e){
+    e.preventDefault();
     terminal.wrongLetter = false;
     socket.emit("keyPressed", key);
 }


### PR DESCRIPTION
Using the apostrophe `'` key will trigger quick find in Firefox, using `e.preventDefault()` stops this from occuring.